### PR TITLE
Update GitHub url of Papercut-SMTP

### DIFF
--- a/src/Papercut.UI/Views/MainView.xaml
+++ b/src/Papercut.UI/Views/MainView.xaml
@@ -172,7 +172,7 @@
 
             <Label Margin="53,0,0,2" VerticalAlignment="Bottom" FontSize="9" Foreground="#2e74a6" Cursor="Hand"
                    ToolTip="Click to visit the site" Grid.Column="2" Grid.Row="1"
-                   Content="https://github.com/ChangemakerStudios/Papercut"
+                   Content="https://github.com/ChangemakerStudios/Papercut-SMTP"
                    HorizontalAlignment="Left" cal:Message.Attach="[Event MouseUp] = [Action GoToSite]" />
         </Grid>
     </Grid>


### PR DESCRIPTION
Since the product is renamed, and has a new GutHub url, the url in the UI should reflect this.