### PR TITLE
~Fix problem when no specified hostname is used at HttpBaseAddress

### DIFF
--- a/src/Papercut.App.WebApi/WebServer.cs
+++ b/src/Papercut.App.WebApi/WebServer.cs
@@ -99,12 +99,12 @@ namespace Papercut.App.WebApi
         void StartHttpServer()
         {
             if (this._isActive) return;
-
-            var uri = new UriBuilder(this._httpBaseAddress) { Port = this._httpPort }.Uri;
-
+            string uri = string.Empty;
             try
             {
-                this._webAppDisposable = WebApp.Start(uri.ToString(), builder =>
+                uri = $"{this._httpBaseAddress}:{this._httpPort}";
+
+                this._webAppDisposable = WebApp.Start(uri, builder =>
                 {
                     var config = new HttpConfiguration();
 

--- a/src/Papercut.Service/Papercut.Service.Settings.json
+++ b/src/Papercut.Service/Papercut.Service.Settings.json
@@ -1,6 +1,6 @@
 ﻿{
   "HttpBaseAddress": "http://127.0.0.1",
-  "HttpBaseAddress_Description": "## The Papercut Web UI Server listening address (Defaults to http://127.0.0.1).",
+  "HttpBaseAddress_Description": "## The Papercut Web UI Server listening address e.g. specific hostname http://hostname (Defaults to http://127.0.0.1). If you want listen to all hostnames use http://* . Warning: This option needs administrator permission. Please be carfully with this option for security reason! ",
   "HttpPort": "37408",
   "HttpPort_Description": "## The Http Web UI Server listening port (Defaults to 37408). Set to 0 to disable Http Web UI Server.",
   "HttpServerEnabled": "True",


### PR DESCRIPTION
~Fix problem when no specified hostname is used at HttpBaseAddress
~Change config file description how to use with no specified hostname