### PR TITLE
Patch net8: Do not update the log WebView2 component every second

### DIFF
--- a/src/Papercut.UI/ViewModels/MainViewModel.cs
+++ b/src/Papercut.UI/ViewModels/MainViewModel.cs
@@ -367,7 +367,7 @@ namespace Papercut.ViewModels
                     h => this._uiLogSinkQueue.LogEvent += h,
                     h => this._uiLogSinkQueue.LogEvent -= h,
                     TaskPoolScheduler.Default)
-                .Buffer(TimeSpan.FromSeconds(1))
+                .Buffer(TimeSpan.FromSeconds(1)) // this will cause calling the Subscribe method every second.
                 .Select(
                     _ =>
                     {
@@ -379,6 +379,9 @@ namespace Papercut.ViewModels
                 .ObserveOn(Dispatcher.CurrentDispatcher).Subscribe(
                     o =>
                     {
+                        // If nothing added, return and don't process any data. And don't change LogText which would update the logs WebView2 component.
+                        if(!o.Any()) { return; }
+
                         foreach (var s in o) this.CurrentLogHistory.PushFront(s);
 
                         if (this.CurrentLogHistory.Count > 150)


### PR DESCRIPTION
This will cause starting and stopping msedgewebview2.exe processes every second.