### PR TITLE
Drop service installation mention from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Papercut SMTP UI Requires the "WebView2" Microsoft shared system component to be
 ![Logging View](https://changemakerstudios.us/content/images/2020/07/Papercut-Log.png)
 
 ## Papercut SMTP Service
-Papercut SMTP has an optional HTTP server to receive emails even when the client is not running. It's installed by default with [Papercut.Setup.exe](https://github.com/ChangemakerStudios/Papercut/releases).
-Alternatively, it can be run in an almost portable way by downloading [Papercut.Service.zip](https://github.com/ChangemakerStudios/Papercut/releases), unzipping and [following the service installation instructions](https://github.com/ChangemakerStudios/Papercut/tree/develop/src/Papercut.Service).
+Papercut SMTP has an optional HTTP server to receive emails even when the client is not running.
+It can be run in an almost portable way by downloading [Papercut.Smtp.Service.*.zip](https://github.com/ChangemakerStudios/Papercut/releases), unzipping, and [following the service installation instructions](https://github.com/ChangemakerStudios/Papercut/tree/develop/src/Papercut.Service).
 
 ### Host in Docker
 


### PR DESCRIPTION
As per #277, starting with version 7.0.0 the installer no longer installs a Windows service. There are no plans to reintroduce this due to being practically infeasible.

Update the readme to reflect that the installer does not set up a service.

Resolves #277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README.md to clarify installation and running options for the Papercut SMTP service.
	- Emphasized that the optional HTTP server is installed by default with the `Papercut.Setup.exe` installer.
	- Specified the correct file for portable service setup as `Papercut.Smtp.Service.*.zip`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->