### PR TITLE
Fix attachment double-click opening by enabling UseShellExecute

### DIFF
--- a/src/Papercut.UI/ViewModels/MessageDetailPartsListViewModel.cs
+++ b/src/Papercut.UI/ViewModels/MessageDetailPartsListViewModel.cs
@@ -125,7 +125,7 @@ public sealed class MessageDetailPartsListViewModel : Screen, IMessageDetailItem
                     mimePart.Content.DecodeTo(outputFile);
                 }
 
-                Process.Start(new ProcessStartInfo(tempFileName));
+                Process.Start(new ProcessStartInfo(tempFileName) { UseShellExecute = true });
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
Fixes #280 - Double clicking PDF attachments (and other file types) in the Sections tab now correctly opens files with their associated default application instead of attempting to execute them directly.

## Root Cause
The issue was caused by a .NET Core/.NET 5+ breaking change where `ProcessStartInfo.UseShellExecute` defaults to `false` instead of `true` (as it was in .NET Framework). Without shell execute enabled, `Process.Start()` attempts to execute the file directly rather than using Windows shell file associations.

## Solution
Added `UseShellExecute = true` to the `ProcessStartInfo` in `MessageDetailPartsListViewModel.ViewSection()` method, restoring the expected behavior of opening files with their registered default applications.

## Changes
- Modified `src/Papercut.UI/ViewModels/MessageDetailPartsListViewModel.cs` line 128
- Changed: `Process.Start(new ProcessStartInfo(tempFileName));`
- To: `Process.Start(new ProcessStartInfo(tempFileName) { UseShellExecute = true });`

## Test Plan
- [x] Double-click PDF attachments in the Sections tab - should open in default PDF viewer
- [x] Double-click other file type attachments - should open with associated applications
- [x] Right-click Save As still works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when opening attachments by launching them with the system’s default application.
  * Resolves cases where attachments failed to open or opened in an unexpected program.
  * Enhances compatibility across different system configurations for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->