### PR TITLE
Fix PDF attachment opening on Windows 11 24H2

### DIFF
--- a/src/Papercut.UI/ViewModels/MessageDetailPartsListViewModel.cs
+++ b/src/Papercut.UI/ViewModels/MessageDetailPartsListViewModel.cs
@@ -127,10 +127,11 @@ public sealed class MessageDetailPartsListViewModel : Screen, IMessageDetailItem
 
                 // Set WorkingDirectory to file's directory to avoid path resolution issues on Windows 11
                 // Explicitly set Verb to "open" for reliability with shell file associations
+                var directory = Path.GetDirectoryName(tempFileName) ?? Path.GetTempPath();
                 var processStartInfo = new ProcessStartInfo(tempFileName)
                 {
                     UseShellExecute = true,
-                    WorkingDirectory = Path.GetDirectoryName(tempFileName),
+                    WorkingDirectory = directory,
                     Verb = "open"
                 };
 


### PR DESCRIPTION
## Summary
Fixes #310 - Improves attachment opening reliability on Windows 11 24H2 by setting explicit ProcessStartInfo properties to avoid path resolution issues.

## Problem
Users on Windows 11 Version 24H2 experience errors when double-clicking PDF attachments in the Sections tab:
- Error: "The specified executable is not a valid application for this OS platform"
- Affects both 32-bit and 64-bit versions
- Issue persists despite the previous #280 fix that added `UseShellExecute = true`

## Solution
Enhanced the `Process.Start()` call with additional defensive settings:
- **WorkingDirectory**: Set to temp file's directory to avoid Windows 11 path resolution ambiguities
- **Verb**: Explicitly set to "open" for clearer shell file association handling
- **UseShellExecute**: Maintained as `true` from previous fix

## Changes
- Modified `MessageDetailPartsListViewModel.ViewSection()` method
- Added explicit ProcessStartInfo configuration for attachment opening
- Follows existing patterns from `ExplorerProcessService` in the codebase

## Testing
- Tested with LinqPad script `SendEmailWithPdfAttachment.linq` for generating test emails
- Unable to reproduce original issue locally, but changes follow Windows best practices
- Low-risk defensive fix that addresses reported behavioral changes in Windows 11 24H2

## Technical Details
The error suggests Windows 11 24H2 has changed how shell execution handles temp file paths. Setting `WorkingDirectory` explicitly helps Windows correctly resolve the file context and associated application, preventing the "not a valid application" error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file opening issues on Windows 11 with improved shell integration and working directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->