### PR TITLE
Fix empty state placeholder flicker when switching emails

### DIFF
--- a/src/Papercut.UI/ViewModels/MessageDetailViewModel.cs
+++ b/src/Papercut.UI/ViewModels/MessageDetailViewModel.cs
@@ -302,8 +302,6 @@ public class MessageDetailViewModel : Conductor<IMessageDetailItem>.Collection.O
             return default;
         }
 
-        this.ResetMessage();
-
         if (mailMessageEx != null)
         {
             this.HeaderViewModel.Headers = string.Join("\r\n", mailMessageEx.Headers.Select(h => h.ToString()));
@@ -311,6 +309,7 @@ public class MessageDetailViewModel : Conductor<IMessageDetailItem>.Collection.O
             var parts = mailMessageEx.BodyParts.OfType<MimePart>().ToList();
             var mainBody = parts.GetMainBodyTextPart();
 
+            // Set new values BEFORE clearing old ones to prevent flicker
             this.From = mailMessageEx.From?.ToString() ?? string.Empty;
             this.To = mailMessageEx.To?.ToString() ?? string.Empty;
             this.CC = mailMessageEx.Cc?.ToString() ?? string.Empty;
@@ -338,7 +337,23 @@ public class MessageDetailViewModel : Conductor<IMessageDetailItem>.Collection.O
                     var textPartNotHtml = parts.OfType<TextPart>().Except(new[] { mainBody }).FirstOrDefault();
                     if (textPartNotHtml != null) this.TextBody = textPartNotHtml.GetText(Encoding.UTF8);
                 }
+                else
+                {
+                    this.TextBody = null;
+                }
             }
+            else
+            {
+                this.IsHtml = false;
+                this.HtmlFile = null;
+                this.TextBody = null;
+                this.HtmlViewModel.HtmlFile = null;
+            }
+        }
+        else
+        {
+            // Only reset when there's no message to display
+            this.ResetMessage();
         }
 
         this.SelectedTabIndex = 0;


### PR DESCRIPTION
## Summary
- Fixes the placeholder flicker when clicking between emails or on startup
- Ensures smooth, flicker-free email navigation

## Changes
The placeholder was briefly flashing when switching between emails because `DisplayMimeMessage()` called `ResetMessage()` first, which temporarily set `From` and `Subject` to null. This caused `HasMessage` to become false before the new message loaded, creating a visual flicker.

**Fix:**
- Only call `ResetMessage()` when there's no message to display (null case)
- Set new message properties directly without clearing them first
- Prevents `HasMessage` from toggling false→true during message switches
- Properly handle partial message cases (no body, no HTML, etc.)

## Related
Fixes #268

## Test Plan
- [x] Build succeeds
- [ ] Launch Papercut UI
- [ ] Send multiple test emails
- [ ] Click between emails rapidly - verify no flicker of placeholder
- [ ] Start Papercut - verify no flicker on initial load if messages exist
- [ ] Delete all messages - verify "No Email" placeholder shows correctly
- [ ] Send first email - verify "Select an Email" placeholder shows correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the order of operations when displaying email messages to ensure sender and recipient fields (From, To, CC, Bcc) are properly preserved before any data clearing occurs.
  * Enhanced handling of HTML and plain text message content to render appropriately based on message format.
  * Refined the message reset logic to only clear the view when there is no message to display, preventing unintended data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->