### PR TITLE
Keep Same Tab when Switching between Messages

### DIFF
--- a/src/Papercut.UI/ViewModels/MessageDetailViewModel.cs
+++ b/src/Papercut.UI/ViewModels/MessageDetailViewModel.cs
@@ -356,7 +356,7 @@ public class MessageDetailViewModel : Conductor<IMessageDetailItem>.Collection.O
             this.ResetMessage();
         }
 
-        this.SelectedTabIndex = 0;
+        // Don't reset SelectedTabIndex - preserve user's tab selection when switching messages (Issue #227)
     }
 
     void ResetMessage()


### PR DESCRIPTION
Fixes #227

Previously, the application would reset to the first tab (Message/HTML) whenever the user navigated between different email messages. This made it difficult to compare the same information (e.g., headers) across multiple messages.

Changes:
- Removed the line that reset SelectedTabIndex to 0 in DisplayMimeMessage()
- The selected tab now persists when navigating between messages
- Users can now efficiently compare headers, body, or other tabs across messages

The SelectedTabIndex property maintains its value through the two-way binding with the TabControl, allowing users to stay on their preferred tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tab selection behavior to preserve the user's current tab when switching between messages, rather than automatically resetting to the first tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->