### PR TITLE
Fix email receiving regression in v7.6.1 (issue #339)

### DIFF
--- a/src/Papercut.Infrastructure.Smtp/PapercutSmtpModule.cs
+++ b/src/Papercut.Infrastructure.Smtp/PapercutSmtpModule.cs
@@ -52,7 +52,7 @@ public class PapercutSmtpModule : Module
         builder.Register(
             ctx =>
             {
-                var ipAllowedList = ctx.Resolve<IPAllowedList>();
+                var ipAllowedList = ctx.ResolveOptional<IPAllowedList>() ?? IPAllowedList.AllowAll;
                 var logger = ctx.Resolve<ILogger>().ForContext<IpAllowlistMailboxFilter>();
                 return new DelegatingMailboxFilterFactory(
                     _ => new IpAllowlistMailboxFilter(ipAllowedList, logger));


### PR DESCRIPTION
Restored email receiving functionality that was broken between v7.5.1 and v7.6.1. Modified PapercutSmtpModule to fix SMTP server configuration.

Fixes #339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved SMTP module configuration flexibility by making IP allowlist configuration optional with automatic fallback to default settings, enhancing system robustness when explicit configuration is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->