### PR TITLE
Fix Raw view not reloading when switching between messages (#340)

### DIFF
--- a/src/Papercut.UI/ViewModels/MessageDetailRawViewModel.cs
+++ b/src/Papercut.UI/ViewModels/MessageDetailRawViewModel.cs
@@ -35,6 +35,8 @@ public class MessageDetailRawViewModel : Screen,
 
     private bool _messageLoaded;
 
+    private MimeMessage? _loadedMimeMessage;
+
     private IDisposable? _messageLoader;
 
     private MimeMessage? _mimeMessage;
@@ -114,9 +116,11 @@ public class MessageDetailRawViewModel : Screen,
 
     private void RefreshDump()
     {
-        if (MessageLoaded)
+        // Don't reload if this exact message instance is already loaded
+        if (MessageLoaded && ReferenceEquals(_loadedMimeMessage, _mimeMessage))
             return;
 
+        // Cancel any in-progress load
         if (_messageLoader != null)
         {
             _messageLoader.Dispose();
@@ -127,20 +131,24 @@ public class MessageDetailRawViewModel : Screen,
         {
             IsLoading = false;
             MessageLoaded = false;
+            _loadedMimeMessage = null;
             Raw = string.Empty;
             return;
         }
 
         IsLoading = true;
+        var messageToLoad = _mimeMessage;
 
         _messageLoader =
-            Observable.Start(() => _mimeMessage.GetStringDump())
+            Observable.Start(() => messageToLoad.GetStringDump())
                 .SubscribeOn(TaskPoolScheduler.Default)
                 .ObserveOn(Dispatcher.CurrentDispatcher)
                 .Subscribe(h =>
                 {
                     Raw = h;
+                    _loadedMimeMessage = messageToLoad;
                     MessageLoaded = true;
+                    IsLoading = false;
                 });
     }
 
@@ -174,6 +182,10 @@ public class MessageDetailRawViewModel : Screen,
                 typedView.rawEdit.Document = new TextDocument(new StringTextSource(s ?? string.Empty));
                 IsLoading = false;
             });
+
+        // Observe MimeMessage changes and refresh when it changes
+        this.GetPropertyValues(p => p.MimeMessage)
+            .Subscribe(_ => RefreshDump());
 
         // Hook up zoom functionality
         typedView.rawEdit.PreviewMouseWheel += (sender, e) =>


### PR DESCRIPTION
## Summary
Fixes issue where the Raw view showed blank content for alternating messages when clicking through the message list while already on the Raw tab.

## Problem
- The `MessageLoaded` flag was a simple boolean that didn't track which specific message instance was loaded
- When switching messages quickly, the flag could remain `true` from a previous message load
- This caused `RefreshDump()` to skip loading the new message, resulting in blank content

## Solution
1. **Added message instance tracking**: New `_loadedMimeMessage` field tracks which specific message is currently loaded
2. **Reference equality check**: Updated `RefreshDump()` to use `ReferenceEquals()` to compare message instances before skipping reload
3. **Reactive subscription**: Added `GetPropertyValues()` observer for `MimeMessage` property changes to trigger reloads
4. **Race condition handling**: Captures message reference in local variable before async loading

## Changes
- Added `_loadedMimeMessage` field to track the loaded message instance
- Updated `RefreshDump()` logic to check reference equality: `ReferenceEquals(_loadedMimeMessage, _mimeMessage)`
- Added reactive observer: `this.GetPropertyValues(p => p.MimeMessage).Subscribe(_ => RefreshDump())`
- Clear `_loadedMimeMessage` when message is null
- Store loaded message reference after successful async load

## Test plan
- [x] Switch to Raw view
- [x] Click through multiple messages in the list
- [x] Verify Raw view content updates for every message
- [x] No blank content on alternating messages
- [x] Build succeeds with no errors

Fixes #340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved performance of raw message display by eliminating unnecessary reloads.
  * Enhanced reliability of message content updates with automatic UI refresh when message properties change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->