### PR TITLE
Document Aspire integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Access at: **http://localhost:37408** | Send emails to: **localhost:2525**
 
 Papercut SMTP can be used for local email testing with Aspire projects. The integration exposes a connection string with the format `endpoint=smtp://<host>:<port>` which can be used to configure the SMTP client.
 
-**Setup**
+#### Setup
 
 Install the package `CommunityToolkit.Aspire.Hosting.PapercutSmtp` from NuGet and then configure the integration in your App Host as follows:
 


### PR DESCRIPTION
Do changes to README automatically reflect in https://www.papercut-smtp.com/? 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Aspire Integration section to the README covering how to use Papercut SMTP with Aspire projects.
  * Includes connection string format, a setup snippet, a complete wiring example, and a note that ports are auto-assigned and exposed via the Aspire dashboard.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->