### PR TITLE
fix: apply cutoff timestamp to Delete All to avoid deleting new messa…

### DIFF
--- a/src/Papercut.UI/ViewModels/MainViewModel.cs
+++ b/src/Papercut.UI/ViewModels/MainViewModel.cs
@@ -95,6 +95,10 @@ public class MainViewModel : Conductor<object>,
 
     public Deque<string> CurrentLogHistory = new();
 
+    private DateTime? _deleteAllCutoff;
+
+    private int _deleteAllCount;
+
     public MainViewModel(
         IViewModelWindowManager viewModelWindowManager,
         IAppCommandHub appCommandHub,
@@ -221,6 +225,19 @@ public class MainViewModel : Conductor<object>,
             {
                 this._isDeleteAllConfirmOpen = value;
                 this.NotifyOfPropertyChange(() => this.IsDeleteAllConfirmOpen);
+            }
+        }
+    }
+    
+    public int DeleteAllCount
+    {
+        get => this._deleteAllCount;
+        set
+        {
+            if (this._deleteAllCount != value)
+            {
+                this._deleteAllCount = value;
+                this.NotifyOfPropertyChange(() => this.DeleteAllCount);
             }
         }
     }
@@ -571,18 +588,23 @@ public class MainViewModel : Conductor<object>,
 
     public void DeleteAll()
     {
-        this.MessageListViewModel.DeleteAll();
+        if (this._deleteAllCutoff.HasValue)
+            this.MessageListViewModel.DeleteAll(this._deleteAllCutoff.Value);
+        this._deleteAllCutoff = null;
         this.IsDeleteAllConfirmOpen = false;
     }
 
     public void CancelDeleteAll()
     {
+        this._deleteAllCutoff = null;
         this.IsDeleteAllConfirmOpen = false;
     }
 
     public void ShowConfirmDeleteAll()
     {
         this.CloseFlyouts();
+        this._deleteAllCutoff = DateTime.Now;
+        this.DeleteAllCount = this.MessageListViewModel.Messages.Count;
         this.IsDeleteAllConfirmOpen = true;
     }
 

--- a/src/Papercut.UI/ViewModels/MessageListViewModel.cs
+++ b/src/Papercut.UI/ViewModels/MessageListViewModel.cs
@@ -334,9 +334,8 @@ public class MessageListViewModel : Screen, IHandle<SettingsUpdatedEvent>
         }
     }
 
-    public void DeleteAll()
+    public void DeleteAll(DateTime cutoff)
     {
-        var cutoff = DateTime.Now;
         this.ClearSelected();
         this.DeleteMessages(this.Messages.Where(m => m.ModifiedDate < cutoff).ToList());
     }

--- a/src/Papercut.UI/Views/MainView.xaml
+++ b/src/Papercut.UI/Views/MainView.xaml
@@ -88,7 +88,7 @@
             <controls:Flyout Header="Delete All" IsOpen="{Binding IsDeleteAllConfirmOpen}" Width="225" Name="DeleteAllFlyout" Position="Left">
                 <StackPanel VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Height="Auto" Margin="4 4 4 4">
                     <TextBlock FontSize="16" TextAlignment="Center" Margin="0 8 0 0">
-                        Delete all <TextBlock FontWeight="Bold" Text="{Binding Path=MessageListViewModel.Messages.Count}" /> Message(s)?
+                        Delete all <TextBlock FontWeight="Bold" Text="{Binding DeleteAllCount}" /> Message(s)?
                     </TextBlock>
                     <Button Margin="4 32 4 0" Style="{StaticResource  MahApps.Styles.Button.Square.Accent}"
                             controls:ControlsHelper.ContentCharacterCasing="Normal" 


### PR DESCRIPTION
Fixes #349 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation dialog now shows the number of messages that will be affected by "Delete All".

* **Bug Fixes**
  * "Delete All" now removes only messages older than the configured cutoff timestamp instead of deleting all messages unconditionally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->