### PR TITLE
Add SMTP authentication support to Forward dialog and Name property to rules

### DIFF
--- a/src/Papercut.Core/Domain/Rules/IRule.cs
+++ b/src/Papercut.Core/Domain/Rules/IRule.cs
@@ -28,6 +28,8 @@ public interface IRule : INotifyPropertyChanged
 {
     Guid Id { get; }
 
+    string Name { get; set; }
+
     bool IsEnabled { get; set; }
 
     string Type { get; }

--- a/src/Papercut.Rules/App/RulesRunner.cs
+++ b/src/Papercut.Rules/App/RulesRunner.cs
@@ -61,6 +61,8 @@ public class RulesRunner : IRulesRunner
         if (rules == null) throw new ArgumentNullException(nameof(rules));
         if (messageEntry == null) throw new ArgumentNullException(nameof(messageEntry));
 
+        token.ThrowIfCancellationRequested();
+
         var ruleTasks = new List<Task>();
 
         foreach (var rule in rules.Where(r => r.IsEnabled))
@@ -124,6 +126,10 @@ public class RulesRunner : IRulesRunner
         {
             var ruleDispatcher = _lifetimeScope.Resolve<IRuleDispatcher<TRule>>();
             await ruleDispatcher.DispatchAsync(rule, messageEntry, token);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Papercut.Rules/Domain/Rules/NewMessageRuleBase.cs
+++ b/src/Papercut.Rules/Domain/Rules/NewMessageRuleBase.cs
@@ -31,8 +31,24 @@ public abstract class NewMessageRuleBase : INewMessageRule
 {
     bool _isEnabled;
 
+    string _name;
+
     [Category("Information")]
     public Guid Id { get; protected set; } = Guid.NewGuid();
+
+    [Category("Information")]
+    [DisplayName("Name")]
+    [Description("A friendly name for this rule")]
+    public string Name
+    {
+        get => this._name;
+        set
+        {
+            if (value == this._name) return;
+            this._name = value;
+            this.OnPropertyChanged(nameof(this.Name));
+        }
+    }
 
     [Category("State")]
     [Browsable(true)]
@@ -59,7 +75,7 @@ public abstract class NewMessageRuleBase : INewMessageRule
     public virtual string Description
         =>
             this.GetPropertiesForDescription()
-                .Where(s => !s.Key.IsAny("Id", "Type", "Description"))
+                .Where(s => !s.Key.IsAny("Id", "Name", "Type", "Description"))
                 .OrderBy(s => s.Key)
                 .ToFormattedPairs()
                 .Join("\r\n");

--- a/src/Papercut.Rules/Domain/Rules/PeriodicBackgroundRuleBase.cs
+++ b/src/Papercut.Rules/Domain/Rules/PeriodicBackgroundRuleBase.cs
@@ -31,8 +31,24 @@ public abstract class PeriodicBackgroundRuleBase : IPeriodicBackgroundRule
 {
     bool _isEnabled;
 
+    string _name;
+
     [Category("Information")]
     public Guid Id { get; protected set; } = Guid.NewGuid();
+
+    [Category("Information")]
+    [DisplayName("Name")]
+    [Description("A friendly name for this rule")]
+    public string Name
+    {
+        get => this._name;
+        set
+        {
+            if (value == this._name) return;
+            this._name = value;
+            this.OnPropertyChanged(nameof(this.Name));
+        }
+    }
 
     [Category("State")]
     [Browsable(true)]
@@ -59,7 +75,7 @@ public abstract class PeriodicBackgroundRuleBase : IPeriodicBackgroundRule
     public virtual string Description
         =>
             this.GetPropertiesForDescription()
-                .Where(s => !s.Key.IsAny("Id", "Type", "Description"))
+                .Where(s => !s.Key.IsAny("Id", "Name", "Type", "Description"))
                 .OrderBy(s => s.Key)
                 .ToFormattedPairs()
                 .Join("\r\n");

--- a/src/Papercut.UI/Properties/Settings.Designer.cs
+++ b/src/Papercut.UI/Properties/Settings.Designer.cs
@@ -97,6 +97,54 @@ namespace Papercut.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string ForwardSmtpUsername {
+            get {
+                return ((string)(this["ForwardSmtpUsername"]));
+            }
+            set {
+                this["ForwardSmtpUsername"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string ForwardSmtpPassword {
+            get {
+                return ((string)(this["ForwardSmtpPassword"]));
+            }
+            set {
+                this["ForwardSmtpPassword"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("25")]
+        public int ForwardSmtpPort {
+            get {
+                return ((int)(this["ForwardSmtpPort"]));
+            }
+            set {
+                this["ForwardSmtpPort"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ForwardSmtpUseSsl {
+            get {
+                return ((bool)(this["ForwardSmtpUseSsl"]));
+            }
+            set {
+                this["ForwardSmtpUseSsl"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool MinimizeOnClose {
             get {

--- a/src/Papercut.UI/Properties/Settings.settings
+++ b/src/Papercut.UI/Properties/Settings.settings
@@ -20,6 +20,18 @@
     <Setting Name="ForwardTo" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="ForwardSmtpUsername" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="ForwardSmtpPassword" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="ForwardSmtpPort" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">25</Value>
+    </Setting>
+    <Setting Name="ForwardSmtpUseSsl" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="MinimizeOnClose" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>

--- a/src/Papercut.UI/ViewModels/ForwardViewModel.cs
+++ b/src/Papercut.UI/ViewModels/ForwardViewModel.cs
@@ -192,7 +192,7 @@ public class ForwardViewModel : Screen
     {
         AvailableRules.Clear();
 
-        var relayRules = _ruleService.Rules.OfType<RelayRule>();
+        var relayRules = _ruleService.Rules.OfType<ForwardRule>();
         foreach (var rule in relayRules)
         {
             AvailableRules.Add(new RelayRuleListItem(rule));
@@ -206,7 +206,7 @@ public class ForwardViewModel : Screen
         this.To = Settings.Default.ForwardTo;
         this.From = Settings.Default.ForwardFrom;
         this.Username = Settings.Default.ForwardSmtpUsername;
-        this.Password = Settings.Default.ForwardSmtpPassword;
+        // Password is intentionally not persisted to settings for security
         this.Port = Settings.Default.ForwardSmtpPort;
         this.UseSsl = Settings.Default.ForwardSmtpUseSsl;
     }
@@ -244,6 +244,14 @@ public class ForwardViewModel : Screen
             return;
         }
 
+        if (this.Port < 1 || this.Port > 65535)
+        {
+            _uiCommandHub.ShowMessage(
+                "SMTP port must be between 1 and 65535.",
+                AppConstants.ApplicationName);
+            return;
+        }
+
         if (this.FromSetting)
         {
             // Save settings for the next time
@@ -251,7 +259,7 @@ public class ForwardViewModel : Screen
             Settings.Default.ForwardTo = this.To.Trim();
             Settings.Default.ForwardFrom = this.From.Trim();
             Settings.Default.ForwardSmtpUsername = this.Username?.Trim() ?? string.Empty;
-            Settings.Default.ForwardSmtpPassword = this.Password ?? string.Empty;
+            // Password is intentionally not persisted to settings for security
             Settings.Default.ForwardSmtpPort = this.Port;
             Settings.Default.ForwardSmtpUseSsl = this.UseSsl;
             Settings.Default.Save();

--- a/src/Papercut.UI/ViewModels/ForwardViewModel.cs
+++ b/src/Papercut.UI/ViewModels/ForwardViewModel.cs
@@ -55,6 +55,8 @@ public class ForwardViewModel : Screen
 
     bool _useSsl;
 
+    bool _useAuthentication;
+
     string _windowTitle = "Forward Message";
 
     RelayRuleListItem _selectedRule;
@@ -156,7 +158,25 @@ public class ForwardViewModel : Screen
         }
     }
 
+    public bool UseAuthentication
+    {
+        get => this._useAuthentication;
+        set
+        {
+            this._useAuthentication = value;
+            this.NotifyOfPropertyChange(() => this.UseAuthentication);
+
+            if (!value)
+            {
+                this.Username = string.Empty;
+                this.Password = string.Empty;
+            }
+        }
+    }
+
     public ObservableCollection<RelayRuleListItem> AvailableRules { get; }
+
+    public bool HasAvailableRules => AvailableRules.Count > 0;
 
     public RelayRuleListItem SelectedRule
     {
@@ -178,6 +198,9 @@ public class ForwardViewModel : Screen
         this.Server = rule.SmtpServer;
         this.Port = rule.SmtpPort;
         this.UseSsl = rule.SmtpUseSSL;
+
+        var hasCredentials = !string.IsNullOrEmpty(rule.SmtpUsername) || !string.IsNullOrEmpty(rule.SmtpPassword);
+        this.UseAuthentication = hasCredentials;
         this.Username = rule.SmtpUsername;
         this.Password = rule.SmtpPassword;
 
@@ -197,6 +220,8 @@ public class ForwardViewModel : Screen
         {
             AvailableRules.Add(new RelayRuleListItem(rule));
         }
+
+        this.NotifyOfPropertyChange(() => this.HasAvailableRules);
     }
 
     void Load()

--- a/src/Papercut.UI/ViewModels/ForwardViewModel.cs
+++ b/src/Papercut.UI/ViewModels/ForwardViewModel.cs
@@ -1,14 +1,14 @@
-﻿// Papercut
-// 
+// Papercut
+//
 // Copyright © 2008 - 2012 Ken Robertson
 // Copyright © 2013 - 2025 Jaben Cargman
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,10 +16,15 @@
 // limitations under the License.
 
 
+using System.Collections.ObjectModel;
 using System.Text.RegularExpressions;
 
+using Papercut.AppLayer.Rules;
 using Papercut.Core;
+using Papercut.Core.Domain.Rules;
 using Papercut.Domain.UiCommands;
+using Papercut.Rules.Domain.Forwarding;
+using Papercut.Rules.Domain.Relaying;
 
 namespace Papercut.ViewModels;
 
@@ -32,6 +37,8 @@ public class ForwardViewModel : Screen
 
     readonly IUiCommandHub _uiCommandHub;
 
+    readonly RuleService _ruleService;
+
     string _from;
 
     bool _fromSetting;
@@ -40,11 +47,23 @@ public class ForwardViewModel : Screen
 
     string _to;
 
+    string _username;
+
+    string _password;
+
+    int _port = 25;
+
+    bool _useSsl;
+
     string _windowTitle = "Forward Message";
 
-    public ForwardViewModel(IUiCommandHub uiCommandHub)
+    RelayRuleListItem _selectedRule;
+
+    public ForwardViewModel(IUiCommandHub uiCommandHub, RuleService ruleService)
     {
         _uiCommandHub = uiCommandHub;
+        _ruleService = ruleService;
+        AvailableRules = new ObservableCollection<RelayRuleListItem>();
     }
 
     public bool FromSetting
@@ -97,12 +116,99 @@ public class ForwardViewModel : Screen
         }
     }
 
+    public string Username
+    {
+        get => this._username;
+        set
+        {
+            this._username = value;
+            this.NotifyOfPropertyChange(() => this.Username);
+        }
+    }
+
+    public string Password
+    {
+        get => this._password;
+        set
+        {
+            this._password = value;
+            this.NotifyOfPropertyChange(() => this.Password);
+        }
+    }
+
+    public int Port
+    {
+        get => this._port;
+        set
+        {
+            this._port = value;
+            this.NotifyOfPropertyChange(() => this.Port);
+        }
+    }
+
+    public bool UseSsl
+    {
+        get => this._useSsl;
+        set
+        {
+            this._useSsl = value;
+            this.NotifyOfPropertyChange(() => this.UseSsl);
+        }
+    }
+
+    public ObservableCollection<RelayRuleListItem> AvailableRules { get; }
+
+    public RelayRuleListItem SelectedRule
+    {
+        get => this._selectedRule;
+        set
+        {
+            this._selectedRule = value;
+            this.NotifyOfPropertyChange(() => this.SelectedRule);
+
+            if (value?.Rule != null)
+            {
+                PopulateFromRule(value.Rule);
+            }
+        }
+    }
+
+    void PopulateFromRule(RelayRule rule)
+    {
+        this.Server = rule.SmtpServer;
+        this.Port = rule.SmtpPort;
+        this.UseSsl = rule.SmtpUseSSL;
+        this.Username = rule.SmtpUsername;
+        this.Password = rule.SmtpPassword;
+
+        if (rule is ForwardRule forwardRule)
+        {
+            this.From = forwardRule.FromEmail;
+            this.To = forwardRule.ToEmail;
+        }
+    }
+
+    void LoadAvailableRules()
+    {
+        AvailableRules.Clear();
+
+        var relayRules = _ruleService.Rules.OfType<RelayRule>();
+        foreach (var rule in relayRules)
+        {
+            AvailableRules.Add(new RelayRuleListItem(rule));
+        }
+    }
+
     void Load()
     {
         // Load previous settings
         this.Server = Settings.Default.ForwardServer;
         this.To = Settings.Default.ForwardTo;
         this.From = Settings.Default.ForwardFrom;
+        this.Username = Settings.Default.ForwardSmtpUsername;
+        this.Password = Settings.Default.ForwardSmtpPassword;
+        this.Port = Settings.Default.ForwardSmtpPort;
+        this.UseSsl = Settings.Default.ForwardSmtpUseSsl;
     }
 
     public async Task Cancel()
@@ -113,6 +219,8 @@ public class ForwardViewModel : Screen
     protected override void OnViewLoaded(object view)
     {
         base.OnViewLoaded(view);
+
+        LoadAvailableRules();
 
         if (this.FromSetting) this.Load();
     }
@@ -142,9 +250,41 @@ public class ForwardViewModel : Screen
             Settings.Default.ForwardServer = this.Server.Trim();
             Settings.Default.ForwardTo = this.To.Trim();
             Settings.Default.ForwardFrom = this.From.Trim();
+            Settings.Default.ForwardSmtpUsername = this.Username?.Trim() ?? string.Empty;
+            Settings.Default.ForwardSmtpPassword = this.Password ?? string.Empty;
+            Settings.Default.ForwardSmtpPort = this.Port;
+            Settings.Default.ForwardSmtpUseSsl = this.UseSsl;
             Settings.Default.Save();
         }
 
         await this.TryCloseAsync(true);
     }
+}
+
+public class RelayRuleListItem
+{
+    public RelayRuleListItem(RelayRule rule)
+    {
+        Rule = rule;
+    }
+
+    public RelayRule Rule { get; }
+
+    public string DisplayName
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(Rule.Name))
+                return Rule.Name;
+
+            var type = Rule.Type;
+            var server = Rule.SmtpServer;
+            if (Rule is ForwardRule fwd && !string.IsNullOrWhiteSpace(fwd.ToEmail))
+                return $"{type} - {server} -> {fwd.ToEmail}";
+
+            return $"{type} - {server}";
+        }
+    }
+
+    public override string ToString() => DisplayName;
 }

--- a/src/Papercut.UI/ViewModels/MainViewModel.cs
+++ b/src/Papercut.UI/ViewModels/MainViewModel.cs
@@ -697,11 +697,11 @@ public class MainViewModel : Conductor<object>,
             {
                 FromEmail = forwardViewModel.From,
                 ToEmail = forwardViewModel.To,
-                SmtpServer = forwardViewModel.Server.Trim(),
+                SmtpServer = forwardViewModel.Server?.Trim() ?? string.Empty,
                 SmtpPort = forwardViewModel.Port,
                 SmtpUseSSL = forwardViewModel.UseSsl,
-                SmtpUsername = forwardViewModel.Username,
-                SmtpPassword = forwardViewModel.Password
+                SmtpUsername = forwardViewModel.Username ?? string.Empty,
+                SmtpPassword = forwardViewModel.Password ?? string.Empty
             };
 
             // send message using relay dispatcher...

--- a/src/Papercut.UI/ViewModels/MainViewModel.cs
+++ b/src/Papercut.UI/ViewModels/MainViewModel.cs
@@ -36,7 +36,6 @@ using Papercut.Domain.UiCommands.Commands;
 using Papercut.Infrastructure.Resources;
 using Papercut.Infrastructure.WebView;
 using Papercut.Rules.App.Forwarding;
-using Papercut.Rules.App.Relaying;
 using Papercut.Rules.Domain.Forwarding;
 using Papercut.Views;
 
@@ -697,10 +696,13 @@ public class MainViewModel : Conductor<object>,
             var forwardRule = new ForwardRule
             {
                 FromEmail = forwardViewModel.From,
-                ToEmail = forwardViewModel.To
+                ToEmail = forwardViewModel.To,
+                SmtpServer = forwardViewModel.Server.Trim(),
+                SmtpPort = forwardViewModel.Port,
+                SmtpUseSSL = forwardViewModel.UseSsl,
+                SmtpUsername = forwardViewModel.Username,
+                SmtpPassword = forwardViewModel.Password
             };
-
-            forwardRule.PopulateServerFromUri(forwardViewModel.Server);
 
             // send message using relay dispatcher...
             await this._forwardRuleDispatch.DispatchAsync(

--- a/src/Papercut.UI/Views/ForwardView.xaml
+++ b/src/Papercut.UI/Views/ForwardView.xaml
@@ -20,6 +20,9 @@
                       BorderThickness="{DynamicResource AccentBorderThickness}"
                       GlowBrush="{DynamicResource AccentGlowBrush}"
                       BorderBrush="{DynamicResource AccentBorderBrush}">
+    <controls:MetroWindow.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </controls:MetroWindow.Resources>
     <Grid Margin="8">
         <DockPanel>
             <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,8,0,0"
@@ -44,6 +47,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <!-- Use Rule dropdown -->
@@ -52,6 +56,7 @@
                           ItemsSource="{Binding AvailableRules}"
                           SelectedItem="{Binding SelectedRule}"
                           DisplayMemberPath="DisplayName"
+                          IsEnabled="{Binding HasAvailableRules}"
                           controls:TextBoxHelper.Watermark="(manual entry)" />
 
                 <!-- Separator -->
@@ -74,21 +79,29 @@
                           IsChecked="{Binding UseSsl}" />
 
                 <!-- Authentication -->
-                <Label Grid.Column="0" Grid.Row="5" Content="Username:" Height="24"/>
-                <TextBox Grid.Column="1" Grid.Row="5" Margin="2" TabIndex="3"
-                         x:Name="Username" />
+                <Label Grid.Column="0" Grid.Row="5" Content="Authenticate:" Height="24"/>
+                <CheckBox Grid.Column="1" Grid.Row="5" Margin="2,5,2,2" TabIndex="3"
+                          IsChecked="{Binding UseAuthentication}" />
 
-                <Label Grid.Column="0" Grid.Row="6" Content="Password:" Height="24"/>
-                <PasswordBox Grid.Column="1" Grid.Row="6" Margin="2" TabIndex="4"
-                             behaviors:PasswordBoxBindingBehavior.Password="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <Label Grid.Column="0" Grid.Row="6" Content="Username:" Height="24"
+                       Visibility="{Binding UseAuthentication, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                <TextBox Grid.Column="1" Grid.Row="6" Margin="2" TabIndex="4"
+                         x:Name="Username"
+                         Visibility="{Binding UseAuthentication, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                <Label Grid.Column="0" Grid.Row="7" Content="Password:" Height="24"
+                       Visibility="{Binding UseAuthentication, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                <PasswordBox Grid.Column="1" Grid.Row="7" Margin="2" TabIndex="5"
+                             behaviors:PasswordBoxBindingBehavior.Password="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                             Visibility="{Binding UseAuthentication, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                 <!-- Email addresses -->
-                <Label Grid.Column="0" Grid.Row="7" Content="From:" Margin="0,2,0,0"/>
-                <TextBox Grid.Column="1" Grid.Row="7" Margin="2" TabIndex="5"
+                <Label Grid.Column="0" Grid.Row="8" Content="From:" Margin="0,2,0,0"/>
+                <TextBox Grid.Column="1" Grid.Row="8" Margin="2" TabIndex="6"
                          x:Name="From" />
 
-                <Label Grid.Column="0" Grid.Row="8" Content="To:"/>
-                <TextBox Grid.Column="1" Grid.Row="8" Margin="2" TabIndex="6"
+                <Label Grid.Column="0" Grid.Row="9" Content="To:"/>
+                <TextBox Grid.Column="1" Grid.Row="9" Margin="2" TabIndex="7"
                          x:Name="To" />
             </Grid>
         </DockPanel>

--- a/src/Papercut.UI/Views/ForwardView.xaml
+++ b/src/Papercut.UI/Views/ForwardView.xaml
@@ -1,4 +1,4 @@
-﻿<controls:MetroWindow x:Class="Papercut.Views.ForwardView"
+<controls:MetroWindow x:Class="Papercut.Views.ForwardView"
                       xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -9,19 +9,20 @@
                       xmlns:Helpers="clr-namespace:Papercut.Helpers"
                       xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                       xmlns:behaviours="http://metro.mahapps.com/winfx/xaml/shared"
+                      xmlns:behaviors="clr-namespace:MahApps.Metro.Behaviors;assembly=MahApps.Metro"
                       mc:Ignorable="d"
                       d:DataContext="{x:Type ViewModels:ForwardViewModel}"
                       Title="{Binding WindowTitle}"
-                      ResizeMode="NoResize" Width="243" Height="162.333"
+                      ResizeMode="NoResize" Width="340" Height="360"
                       WindowStyle="ToolWindow"
                       ShowIconOnTitleBar="false"
-                      WindowStartupLocation="CenterOwner" 
-                      BorderThickness="{DynamicResource AccentBorderThickness}" 
+                      WindowStartupLocation="CenterOwner"
+                      BorderThickness="{DynamicResource AccentBorderThickness}"
                       GlowBrush="{DynamicResource AccentGlowBrush}"
                       BorderBrush="{DynamicResource AccentBorderBrush}">
-    <Grid>
+    <Grid Margin="8">
         <DockPanel>
-            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="2"
+            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,8,0,0"
                         FrameworkElement.FlowDirection="RightToLeft" Height="30">
                 <Button Width="75" Margin="2" Name="Cancel">Cancel</Button>
                 <Button Width="75" Margin="2" Name="Send" IsDefault="True">
@@ -37,15 +38,57 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
-                <Label Grid.Column="0" Grid.Row="0" Content="SMTP Server:" Height="24"/>
-                <Label Grid.Column="0" Grid.Row="1" Content="From:" Margin="0,2,0,0"/>
-                <Label Grid.Column="0" Grid.Row="2" Content="To:"/>
-                <TextBox Grid.Column="1" Grid.Row="0" Margin="2,2,0,3" Width="150" TabIndex="0" HorizontalAlignment="Left"
+
+                <!-- Use Rule dropdown -->
+                <Label Grid.Column="0" Grid.Row="0" Content="Use Rule:" Height="28" VerticalAlignment="Center"/>
+                <ComboBox Grid.Column="1" Grid.Row="0" Margin="2" Height="26"
+                          ItemsSource="{Binding AvailableRules}"
+                          SelectedItem="{Binding SelectedRule}"
+                          DisplayMemberPath="DisplayName"
+                          controls:TextBoxHelper.Watermark="(manual entry)" />
+
+                <!-- Separator -->
+                <Separator Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Margin="0,4" />
+
+                <!-- Server settings -->
+                <Label Grid.Column="0" Grid.Row="2" Content="SMTP Server:" Height="24"/>
+                <TextBox Grid.Column="1" Grid.Row="2" Margin="2" TabIndex="0"
                          x:Name="Server" />
-                <TextBox Grid.Column="1" Grid.Row="1" Margin="2" Width="150" TabIndex="1" HorizontalAlignment="Left"
+
+                <Label Grid.Column="0" Grid.Row="3" Content="Port:" Height="24"/>
+                <controls:NumericUpDown Grid.Column="1" Grid.Row="3" Margin="2" TabIndex="1"
+                         Value="{Binding Port, Mode=TwoWay}"
+                         Minimum="1" Maximum="65535"
+                         HideUpDownButtons="False"
+                         Width="100" HorizontalAlignment="Left" />
+
+                <Label Grid.Column="0" Grid.Row="4" Content="Use SSL:" Height="24"/>
+                <CheckBox Grid.Column="1" Grid.Row="4" Margin="2,5,2,2" TabIndex="2"
+                          IsChecked="{Binding UseSsl}" />
+
+                <!-- Authentication -->
+                <Label Grid.Column="0" Grid.Row="5" Content="Username:" Height="24"/>
+                <TextBox Grid.Column="1" Grid.Row="5" Margin="2" TabIndex="3"
+                         x:Name="Username" />
+
+                <Label Grid.Column="0" Grid.Row="6" Content="Password:" Height="24"/>
+                <PasswordBox Grid.Column="1" Grid.Row="6" Margin="2" TabIndex="4"
+                             behaviors:PasswordBoxBindingBehavior.Password="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                <!-- Email addresses -->
+                <Label Grid.Column="0" Grid.Row="7" Content="From:" Margin="0,2,0,0"/>
+                <TextBox Grid.Column="1" Grid.Row="7" Margin="2" TabIndex="5"
                          x:Name="From" />
-                <TextBox Grid.Column="1" Grid.Row="2" Margin="2" Width="150" TabIndex="2" HorizontalAlignment="Left"
+
+                <Label Grid.Column="0" Grid.Row="8" Content="To:"/>
+                <TextBox Grid.Column="1" Grid.Row="8" Margin="2" TabIndex="6"
                          x:Name="To" />
             </Grid>
         </DockPanel>

--- a/src/Papercut.UI/Views/RulesConfigurationView.xaml
+++ b/src/Papercut.UI/Views/RulesConfigurationView.xaml
@@ -127,7 +127,8 @@
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>
                         <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding IsEnabled}" Width="80" />
-                        <DataGridTextColumn Header="Rule Type" Binding="{Binding Type}" Width="200" />
+                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="120" />
+                        <DataGridTextColumn Header="Rule Type" Binding="{Binding Type}" Width="150" />
                         <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="*" />
                     </DataGrid.Columns>
                 </DataGrid>

--- a/test/Papercut.Rules.Tests/RulesRunnerTests.cs
+++ b/test/Papercut.Rules.Tests/RulesRunnerTests.cs
@@ -43,6 +43,7 @@ public class RulesRunnerTests
     {
         public Guid Id { get; } = Guid.NewGuid();
         public bool IsEnabled { get; set; } = true;
+        public string Name { get; set; } = "TestRule";
         public string Type => "TestRule";
         public string Description => "Test rule for unit tests";
         public event PropertyChangedEventHandler? PropertyChanged;


### PR DESCRIPTION
The Forward dialog now supports SMTP authentication (username/password),
port configuration, and SSL toggle. Users can also select from pre-configured
forwarding rules via a dropdown, which auto-populates all fields. Rules now
have a Name property for easy identification in both the rules list and the
forward dialog's rule picker.

Closes #363

https://claude.ai/code/session_01K1oUZzF99AeJhxX3ScrBcS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rules now support a user-editable friendly Name shown in lists.
  * Forwarding adds SMTP authentication (username/password), custom port and SSL options; username/port/SSL are persisted (password is not).

* **UI Updates**
  * Rules grid displays rule names.
  * Forward configuration UI expanded with rule selector, port, SSL, and auth fields; selected rule can populate forwarding settings and port input is validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->